### PR TITLE
Fix: Add visible shadow to strategy items in dark mode

### DIFF
--- a/src/components/items/StrategyItem.tsx
+++ b/src/components/items/StrategyItem.tsx
@@ -241,7 +241,7 @@ export function StrategyItem({
     // Loading state - skeleton UI to prevent layout shift
     if (isLoading) {
         return (
-            <div className="shadow-sm">
+            <div className="shadow-sm dark:shadow-[0_1px_3px_0_rgba(255,255,255,0.1)]">
                 <div className="flex">
                     {/* Strategy Name Column - 25% */}
                     <div className="w-[25%] border-r border-border p-4">
@@ -286,7 +286,7 @@ export function StrategyItem({
     // Success state - render strategy with dashboard KPIs and actions
     return (
         <div
-            className="relative shadow-sm"
+            className="relative shadow-sm dark:shadow-[0_1px_3px_0_rgba(255,255,255,0.1)]"
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >


### PR DESCRIPTION
## Description
This PR fixes the missing shadow on Strategy Items when in dark mode.

## Problem
In light mode, Strategy Items on the OGSM board have a subtle `shadow-sm` that provides visual separation. However, Tailwind's default shadow uses a dark gray color that becomes nearly invisible against dark backgrounds, making the items appear flat in dark mode.

## Changes Made
- Added a custom shadow for dark mode using Tailwind's arbitrary value syntax
- The dark mode shadow uses `rgba(255,255,255,0.1)` (white with 10% opacity) to provide subtle but visible separation
- Applied to both the loading skeleton state and the rendered strategy items
- Maintains visual consistency across both light and dark themes

## Technical Details
- Used `dark:shadow-[0_1px_3px_0_rgba(255,255,255,0.1)]` to override the default shadow in dark mode
- The white shadow with low opacity ensures visibility without being too prominent
- Shadow dimensions match the default `shadow-sm` size for consistency

## Impact
- Improves visual hierarchy and readability in dark mode
- Ensures consistent and polished user experience across both themes
- Maintains subtle design aesthetic while improving functionality

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode visuals by adding subtle white shadow accents to loading skeletons and content containers for improved depth and contrast in both loading and loaded states. No layout, behavior, or data changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->